### PR TITLE
[FIX] Block model no longer estimates with delays in FISTA solver

### DIFF
--- a/splora/deconvolution/fista.py
+++ b/splora/deconvolution/fista.py
@@ -222,7 +222,10 @@ def fista(
                 keep_diff = np.where(St_diff >= eigen_thr)[0]
 
                 # Use first difference above the threshold as the number of low-rank components.
-                keep_idx = keep_diff[0]
+                if keep_diff.size > 0:
+                    keep_idx = keep_diff[0]
+                else:
+                    keep_idx = 0  # fallback: keep at least one component
 
                 LGR.info(f"{keep_idx+1} low-rank components found")
 

--- a/splora/deconvolution/fista.py
+++ b/splora/deconvolution/fista.py
@@ -3,8 +3,7 @@
 import logging
 
 import numpy as np
-from pySPFM.deconvolution.debiasing import debiasing_block, debiasing_spike
-from pySPFM.deconvolution.hrf_generator import HRFMatrix
+from pySPFM.deconvolution.debiasing import debiasing_spike
 from pySPFM.deconvolution.select_lambda import select_lambda
 from scipy import linalg
 

--- a/splora/deconvolution/fista.py
+++ b/splora/deconvolution/fista.py
@@ -193,7 +193,10 @@ def fista(
         LGR.info(f"Iteration {num_iter + 1}/{max_iter}")
 
         if not pfm_only:
-            data_fidelity = A.copy() - S_fitts
+            if block_model:
+                data_fidelity = y - S_fitts - y_fista_L
+            else:
+                data_fidelity = A.copy() - S_fitts
 
         # Save results from previous iteration
         S_old = S.copy()
@@ -231,7 +234,10 @@ def fista(
                 data_fidelity = y - L
             else:
                 L = np.dot(np.dot(Ut, np.diag(St)), Vt)
-                data_fidelity = A - L
+                if block_model:
+                    data_fidelity = y - L - S_fitts
+                else:
+                    data_fidelity = A - L
 
         if pfm_only:
             S_fidelity = v - np.dot(hrf_cov, y_ista_S)
@@ -243,9 +249,12 @@ def fista(
             else:
                 # Single-echo: project data_fidelity through hrf.T
                 # This handles both full data and subsampled data cases
-                S_fidelity = np.dot(hrf_trans, data_fidelity) - np.dot(
-                    hrf_cov, y_ista_S
-                )
+                if block_model:
+                    S_fidelity = np.dot(hrf_trans, data_fidelity)
+                else:
+                    S_fidelity = np.dot(hrf_trans, data_fidelity) - np.dot(
+                        hrf_cov, y_ista_S
+                    )
 
         z_ista_S = y_ista_S + c_ist * S_fidelity
 
@@ -260,14 +269,8 @@ def fista(
         #  Perform debiasing to have both S and L on the same amplitude scale
         if not pfm_only:
             if block_model:
-                if num_iter == 0:
-                    hrf_obj = HRFMatrix(te=te, block=False)
-                    hrf_norm = hrf_obj.generate_hrf(tr=tr, n_scans=nscans).hrf_
-
-                S_spike = debiasing_block(
-                    hrf=hrf_norm, y=y, estimates_matrix=S, n_jobs=jobs
-                )
-                S_fitts = np.dot(hrf_norm, S_spike)
+                S_spike = S
+                S_fitts = np.dot(hrf, S)
             else:
                 S, S_fitts = debiasing_spike(
                     hrf=hrf, y=y, estimates_matrix=S, n_jobs=jobs
@@ -277,7 +280,7 @@ def fista(
             S_spike = S
             S_fitts = np.dot(hrf, S)
 
-        if not pfm_only:
+        if not pfm_only and not block_model:
             A = y_ista_A + np.dot(hrf, S_spike - y_ista_S) + (L - y_ista_L)
 
         t_fista_old = t_fista

--- a/splora/tests/test_block_model.py
+++ b/splora/tests/test_block_model.py
@@ -1,4 +1,5 @@
 
+
 import numpy as np
 from pySPFM.deconvolution.hrf_generator import HRFMatrix
 from splora.deconvolution import fista
@@ -8,11 +9,11 @@ def test_block_model_delay():
     tr = 2.0
     n_scans = 100
     te = [0]
-    
+
     # Generate HRF matrices
     hrf_obj_block = HRFMatrix(te=te, block=True)
     hrf_block = hrf_obj_block.generate_hrf(tr=tr, n_scans=n_scans).hrf_
-    
+
     # Generate ground truth block signal
     # Innovation signal: +1 at start of block, -1 at end
     n_voxels = 1
@@ -22,51 +23,55 @@ def test_block_model_delay():
     s_innovation[40, :] = -1
     s_innovation[60, :] = 1
     s_innovation[80, :] = -1
-    
+
     # BOLD signal
     y = np.dot(hrf_block, s_innovation)
-    
+
     # Add some noise
     np.random.seed(42)
     y_noisy = y + 0.01 * np.random.randn(*y.shape)
-    
+
     # Run FISTA
     S_est, _, _, _, _, L_est = fista.fista(
         hrf=hrf_block,
         y=y_noisy,
         n_te=1,
         block_model=True,
-        pfm_only=True, # Use PFM only to force S to capture signal
+        pfm_only=True,  # Use PFM only to force S to capture signal
         max_iter=50,
         lambda_crit="factor",
-        factor=0.1, # Low regularization to ensure we catch the signal
+        factor=0.1,  # Low regularization to ensure we catch the signal
         tr=tr,
         te=te,
-        eigen_thr=0.001 # Low threshold
+        eigen_thr=0.001  # Low threshold
     )
-    
+
     # Check onsets
     est_onsets = np.where(np.abs(S_est) > 0.1)[0]
-    
+
     # We expect the estimated onsets to be close to the true onsets
     # Allow for +/- 1 TR error, although with this synthetic data it should be exact
     matched_onsets = 0
     for true_onset in true_onsets:
         if np.any(np.abs(est_onsets - true_onset) <= 1):
             matched_onsets += 1
-            
-    assert matched_onsets == len(true_onsets), f"Failed to recover all onsets. True: {true_onsets}, Est: {est_onsets}"
-    
+
+    assert matched_onsets == len(true_onsets), (
+        f"Failed to recover all onsets. True: {true_onsets}, Est: {est_onsets}"
+    )
+
     # Check that we don't have too many false positives (dense signal)
     # The bug caused the signal to be dense (block-like) instead of sparse (innovation-like)
     # With noise, we might get some smearing, but it shouldn't be a full block (approx 40 points)
-    assert len(est_onsets) < 30, f"Estimated signal is too dense, likely block-like instead of innovation-like. Non-zeros: {len(est_onsets)}"
+    assert len(est_onsets) < 30, (
+        f"Estimated signal is too dense, likely block-like instead of innovation-like. Non-zeros: {len(est_onsets)}"
+    )
 
     # Check reconstruction MSE
     y_fitted = np.dot(hrf_block, S_est)
     residual = y_noisy - y_fitted - L_est
     mse = np.mean(residual**2)
-    
+
     # MSE should be comparable to noise level
     # Note: Regularization introduces bias, so MSE will be higher than noise variance (0.0001)
     assert mse < 0.02, f"MSE is too high: {mse}"

--- a/splora/tests/test_block_model.py
+++ b/splora/tests/test_block_model.py
@@ -1,8 +1,8 @@
-
-
 import numpy as np
 from pySPFM.deconvolution.hrf_generator import HRFMatrix
+
 from splora.deconvolution import fista
+
 
 def test_block_model_delay():
     """Test that block model estimation does not introduce delays."""
@@ -43,7 +43,7 @@ def test_block_model_delay():
         factor=0.1,  # Low regularization to ensure we catch the signal
         tr=tr,
         te=te,
-        eigen_thr=0.001  # Low threshold
+        eigen_thr=0.001,  # Low threshold
     )
 
     # Check onsets
@@ -56,16 +56,18 @@ def test_block_model_delay():
         if np.any(np.abs(est_onsets - true_onset) <= 1):
             matched_onsets += 1
 
-    assert matched_onsets == len(true_onsets), (
-        f"Failed to recover all onsets. True: {true_onsets}, Est: {est_onsets}"
-    )
+    assert matched_onsets == len(
+        true_onsets
+    ), f"Failed to recover all onsets. True: {true_onsets}, Est: {est_onsets}"
 
     # Check that we don't have too many false positives (dense signal)
     # The bug caused the signal to be dense (block-like) instead of sparse (innovation-like)
     # With noise, we might get some smearing, but it shouldn't be a full block (approx 40 points)
-    assert len(est_onsets) < 30, (
-        f"Estimated signal is too dense, likely block-like instead of innovation-like. Non-zeros: {len(est_onsets)}"
+    error_msg = (
+        "Estimated signal is too dense, likely block-like instead of innovation-like. "
+        f"Non-zeros: {len(est_onsets)}"
     )
+    assert len(est_onsets) < 30, error_msg
 
     # Check reconstruction MSE
     y_fitted = np.dot(hrf_block, S_est)
@@ -74,4 +76,5 @@ def test_block_model_delay():
 
     # MSE should be comparable to noise level
     # Note: Regularization introduces bias, so MSE will be higher than noise variance (0.0001)
-    assert mse < 0.02, f"MSE is too high: {mse}"
+    error_msg = f"MSE is too high: {mse}"
+    assert mse < 0.02, error_msg

--- a/splora/tests/test_block_model.py
+++ b/splora/tests/test_block_model.py
@@ -71,7 +71,7 @@ def test_block_model_delay():
 
     # Check reconstruction MSE
     y_fitted = np.dot(hrf_block, S_est)
-    residual = y_noisy - y_fitted - L_est
+    residual = y_noisy - y_fitted
     mse = np.mean(residual**2)
 
     # MSE should be comparable to noise level

--- a/splora/tests/test_block_model.py
+++ b/splora/tests/test_block_model.py
@@ -1,0 +1,72 @@
+
+import numpy as np
+from pySPFM.deconvolution.hrf_generator import HRFMatrix
+from splora.deconvolution import fista
+
+def test_block_model_delay():
+    """Test that block model estimation does not introduce delays."""
+    tr = 2.0
+    n_scans = 100
+    te = [0]
+    
+    # Generate HRF matrices
+    hrf_obj_block = HRFMatrix(te=te, block=True)
+    hrf_block = hrf_obj_block.generate_hrf(tr=tr, n_scans=n_scans).hrf_
+    
+    # Generate ground truth block signal
+    # Innovation signal: +1 at start of block, -1 at end
+    n_voxels = 1
+    s_innovation = np.zeros((n_scans, n_voxels))
+    true_onsets = [20, 40, 60, 80]
+    s_innovation[20, :] = 1
+    s_innovation[40, :] = -1
+    s_innovation[60, :] = 1
+    s_innovation[80, :] = -1
+    
+    # BOLD signal
+    y = np.dot(hrf_block, s_innovation)
+    
+    # Add some noise
+    np.random.seed(42)
+    y_noisy = y + 0.01 * np.random.randn(*y.shape)
+    
+    # Run FISTA
+    S_est, _, _, _, _, L_est = fista.fista(
+        hrf=hrf_block,
+        y=y_noisy,
+        n_te=1,
+        block_model=True,
+        pfm_only=True, # Use PFM only to force S to capture signal
+        max_iter=50,
+        lambda_crit="factor",
+        factor=0.1, # Low regularization to ensure we catch the signal
+        tr=tr,
+        te=te,
+        eigen_thr=0.001 # Low threshold
+    )
+    
+    # Check onsets
+    est_onsets = np.where(np.abs(S_est) > 0.1)[0]
+    
+    # We expect the estimated onsets to be close to the true onsets
+    # Allow for +/- 1 TR error, although with this synthetic data it should be exact
+    matched_onsets = 0
+    for true_onset in true_onsets:
+        if np.any(np.abs(est_onsets - true_onset) <= 1):
+            matched_onsets += 1
+            
+    assert matched_onsets == len(true_onsets), f"Failed to recover all onsets. True: {true_onsets}, Est: {est_onsets}"
+    
+    # Check that we don't have too many false positives (dense signal)
+    # The bug caused the signal to be dense (block-like) instead of sparse (innovation-like)
+    # With noise, we might get some smearing, but it shouldn't be a full block (approx 40 points)
+    assert len(est_onsets) < 30, f"Estimated signal is too dense, likely block-like instead of innovation-like. Non-zeros: {len(est_onsets)}"
+
+    # Check reconstruction MSE
+    y_fitted = np.dot(hrf_block, S_est)
+    residual = y_noisy - y_fitted - L_est
+    mse = np.mean(residual**2)
+    
+    # MSE should be comparable to noise level
+    # Note: Regularization introduces bias, so MSE will be higher than noise variance (0.0001)
+    assert mse < 0.02, f"MSE is too high: {mse}"


### PR DESCRIPTION
Closes #33.

The issue where estimates of the block model showed a delay has been fixed.

Investigation Findings
Root Cause: The [fista](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) solver was using [debiasing_block](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) inside the optimization loop to update the fitted signal [S_fitts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

[debiasing_block](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) returns a Block Signal (amplitudes of blocks), whereas the FISTA algorithm with a Block HRF expects [S](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to be the Innovation Signal (sparse edges).
This domain mismatch caused the optimization to drift, leading [S](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to become a smooth Block Signal instead of sparse Innovation, resulting in delays and incorrect model fitting.
Additionally, the internal acceleration tracking variable [A](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) was being updated incorrectly due to this mismatch.
Verification: A reproduction script confirmed that the internal model was fitting a Block Signal (using Spike HRF) better than the intended Innovation Signal (using Block HRF), and that the estimated onsets were dense and incorrect.

This pull request updates the `fista` function in `splora/deconvolution/fista.py` to improve handling of the `block_model` option and simplify related logic. The changes primarily affect how data fidelity and debiasing are computed depending on whether `block_model` is enabled, making the code paths clearer and more consistent.

**Block model logic improvements:**

* Data fidelity calculation now distinguishes between `block_model` and non-block model cases, ensuring correct subtraction of relevant components (`S_fitts`, `y_fista_L`, or `A`). [[1]](diffhunk://#diff-26293fc7eab00a999c67b17da63640e292c2052862397ca699810e80b16251d3R196-R198) [[2]](diffhunk://#diff-26293fc7eab00a999c67b17da63640e292c2052862397ca699810e80b16251d3R237-R239)
* When projecting `data_fidelity` through `hrf_trans`, the block model path now avoids subtracting `hrf_cov * y_ista_S`, aligning with the intended block model behavior.

**Debiasing simplification:**

* Debiasing for the block model is simplified: the code now directly uses `S` and `hrf` instead of creating a new HRF matrix and running `debiasing_block`, making the process more straightforward and reducing complexity.

**Update logic for `A`:**

* The update for `A` is now skipped when `block_model` is enabled, preventing unnecessary computation and ensuring correct results for block model runs.