### PR TITLE
Add PyPI publish workflow and update badges

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    # This ensures that the publish action only runs in the main repository
+    # rather than forks
+    environment: release
+    if: github.repository_owner == 'Paradigm-Free-Mapping'
+    permissions:
+      id-token: write # this permission is mandatory for pypi publishing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # This fetch element is only important if you are use SCM based
+          # versioning (that looks at git tags to gather the version)
+          fetch-depth: 100
+
+      # Need the tags so that setuptools-scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Hatch
+        run: |
+          pipx install hatch
+          pip list
+
+      - name: Build package using Hatch
+        run: |
+          hatch build
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Publish package to PyPI
+        # Only publish to real PyPI on release
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/splora.svg)](https://pypi.python.org/pypi/splora/)
 [![DOI](https://zenodo.org/badge/291096007.svg)](https://zenodo.org/badge/latestdoi/291096007)
 [![License](https://img.shields.io/badge/License-LGPL%202.1-blue.svg)](https://opensource.org/licenses/LGPL-2.1)
-[![CircleCI](https://circleci.com/gh/eurunuela/splora.svg?style=shield)](https://circleci.com/gh/eurunuela/splora)
+[![CircleCI](https://circleci.com/gh/Paradigm-Free-Mapping/splora.svg?style=shield)](https://circleci.com/gh/Paradigm-Free-Mapping/splora)
 [![Documentation Status](https://readthedocs.org/projects/splora/badge/?version=latest)](http://splora.readthedocs.io/en/latest/?badge=latest)
-[![Codecov](https://codecov.io/gh/eurunuela/splora/branch/main/graph/badge.svg)](https://codecov.io/gh/me-ica/template-package)
+[![Codecov](https://codecov.io/gh/Paradigm-Free-Mapping/splora/branch/main/graph/badge.svg)](https://codecov.io/gh/Paradigm-Free-Mapping/splora)
 
 Repository for SPLORA PFM.
 


### PR DESCRIPTION
Introduced a GitHub Actions workflow for publishing to PyPI on release events. Updated CircleCI and Codecov badges in README to reference the Paradigm-Free-Mapping organization instead of eurunuela.