### PR TITLE
Make it possible to run pypi publishing action without release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,6 +2,7 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch: # Allows manual triggering from Actions tab
 
 jobs:
   build-publish:
@@ -42,6 +43,4 @@ jobs:
           ls -lh dist/
 
       - name: Publish package to PyPI
-        # Only publish to real PyPI on release
-        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 authors = [
-    { name = "Eneko Uruñuela", email = "e.urunuela@bcbl.eu" },
+    { name = "Eneko Uruñuela", email = "eneko.urunuela@ucalgary.ca" },
 ]
 maintainers = [
-    { name = "Eneko Uruñuela", email = "e.urunuela@bcbl.eu" },
+    { name = "Eneko Uruñuela", email = "eneko.urunuela@ucalgary.ca" },
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
This pull request updates the PyPI publishing workflow and corrects author and maintainer contact information in the project metadata. The main changes are grouped below:

**Workflow improvements:**

* Added `workflow_dispatch` to `.github/workflows/python-publish.yml` to enable manual triggering of the PyPI publish workflow from the Actions tab.
* Removed the condition that restricted the PyPI publish step to only run on release events, allowing the step to run on all workflow triggers.

**Metadata corrections:**

* Updated the email address for author and maintainer `Eneko Uruñuela` in `pyproject.toml` to the new contact at `ucalgary.ca`.